### PR TITLE
Auto-Commit PR at 20250328_060036

### DIFF
--- a/logs/log.txt
+++ b/logs/log.txt
@@ -1,0 +1,1 @@
+20250328_060036: Failed to fetch quote: HTTPSConnectionPool(host='zenquotes.io', port=443): Max retries exceeded with url: /api/random (Caused by SSLError(SSLEOFError(8, '[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol (_ssl.c:1000)'))) - Unknown Author


### PR DESCRIPTION
Automated commit from fork:

20250328_060036: Failed to fetch quote: HTTPSConnectionPool(host='zenquotes.io', port=443): Max retries exceeded with url: /api/random (Caused by SSLError(SSLEOFError(8, '[SSL: UNEXPECTED_EOF_WHILE_READING] EOF occurred in violation of protocol (_ssl.c:1000)'))) - Unknown Author


fixes #31